### PR TITLE
core/aalt: bump hash

### DIFF
--- a/core/aalt/APKBUILD
+++ b/core/aalt/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=aalt
-pkgver=0.0.1a
-_hash=b27909a80b161eb7f18a26db4dc68bad97946da6
+pkgver=0.1.0a
+_hash=422f8c9ca731a9ff7f6e5c822771df8b68a544e2
 pkgrel=0
 pkgdesc="Abyss ALTernatives"
 url="https://github.com/5paceToast/aalt"
@@ -24,5 +24,5 @@ package() {
     install -Dm755 "$srcdir"/aalt-bin "$pkgdir"/usr/bin/aalt-bin
 }
 
-b2sums="4a227dde28733ceb460c0c708d42f1e2dc2175949c8930e8b40fd2ada19125e4268634929238ea228a30123d0edb280711bf944fefedc13bdd3d1d2922c19150  aalt-0.0.1a.tar.gz
-f6a3804880cc1d24396946f36ac0ee9835ff89a20aaf1c81081923c70bd3b10ee4a752d30f23d000b53d6b9597241ff1b11d00a3ae586406e8541e5dec53f1e3  aalt-bin"
+b2sums="ba20d60fe028dd5b4a5882d57aa1bdd6a4d1ff0c4846dfa73be19c778318790e7d6a30d1ec0c2140f497f21e5bbc23b845f7d65ef654a80c8fc591ebabe6fc60  aalt-0.0.1a.tar.gz
+c831e539be0edba13d50f4a082b5e95fef98322ffa2613b7cc9d6711399676699d58ff1af39b13253dbedcfc9b0ba42c505b2cc825b998800d469d3d2cbc00ec  aalt-bin"

--- a/core/aalt/aalt-bin
+++ b/core/aalt/aalt-bin
@@ -1,7 +1,7 @@
 #!/bin/zsh
 
-aalt_dest=/usr/bin
-aalt_prefix=/var/lib/aalt/bin
+: ${aalt_dest:=/usr/bin}
+: ${aalt_prefix:=/var/lib/aalt/bin}
 
 fpath+=( /usr/share/aalt.zwc )
 autoload -w /usr/share/aalt.zwc


### PR DESCRIPTION
This adds the -c option.
Also allows overriding dest and prefix via environment in the launcher
script.