### PR TITLE
devel/go: fix patch

### DIFF
--- a/devel/go/APKBUILD
+++ b/devel/go/APKBUILD
@@ -1,6 +1,6 @@
 pkgname=go
 pkgver=1.14.2
-pkgrel=0
+pkgrel=1
 pkgdesc="Go programming language compiler"
 url="https://golang.org/"
 arch="all"
@@ -77,5 +77,5 @@ package() {
 }
 
 b2sums="edd8a1081e7da6988532b9fefe6d6f789a7d336562d61d5e585a8b881fb45d77721bee9837ae79318295471aea138e175650c2138175a587f0b7957988e8e209  go1.14.2.src.tar.gz
-fa4473bd0c5d07e8c6d47430415190d8d1142322448290bff400dce29c2fffedf493487afecb9898ebf1884ef5b3b4fc39d42208e59197c09ef62deb1f0bf083  default-buildmode-pie.patch
+929d7d77820beb9d6917eb8c3b94a388c77cc77386a382556790115fadefc1ac4da3c2b506b8715b1f4fa9ba281179b335eef4f3ec5d6bbc4cef46b993335286  default-buildmode-pie.patch
 092470769860f13720d5399edbbf51f5ab8b7cc18da68e2fa18a89e25e9f98c61195545d2977e724c59190aad78f97f165ac59002cf46697415eff9c7af1e9ed  external-linker.patch"

--- a/devel/go/default-buildmode-pie.patch
+++ b/devel/go/default-buildmode-pie.patch
@@ -1,13 +1,15 @@
 diff --git a/src/cmd/go/internal/work/init.go b/src/cmd/go/internal/work/init.go
-index 7f894f5..a517887 100644
+index 473bd1a31b..7aedf2c7ba 100644
 --- a/src/cmd/go/internal/work/init.go
 +++ b/src/cmd/go/internal/work/init.go
-@@ -131,7 +131,7 @@ func buildModeInit() {
- 		ldBuildmode = "c-shared"
- 	case "default":
- 		switch cfg.Goos {
--		case "android":
-+		case "android", "linux":
- 			codegenArg = "-shared"
- 			ldBuildmode = "pie"
- 		case "darwin":
+@@ -106,6 +106,10 @@ func buildModeInit() {
+ 	// That way, if the flag is completely bogus we will prefer to error out with
+ 	// "-buildmode=%s not supported" instead of naming the specific platform.
+ 
++	if cfg.BuildBuildmode == "default" && cfg.Goos == "linux" && !cfg.BuildRace {
++		cfg.BuildBuildmode = "pie"
++	}
++
+ 	switch cfg.BuildBuildmode {
+ 	case "archive":
+ 		pkgsFilter = pkgsNotMain


### PR DESCRIPTION
go's build modes have more side-effects than what the old patch assumes
this makes it cause all those weird "no runtime/cgo" errors

instead, let's just default to the "pie" buildmode, taking advantage of go's internal system